### PR TITLE
Determine proper UPN at higher level

### DIFF
--- a/auth/oidc/classes/jwt.php
+++ b/auth/oidc/classes/jwt.php
@@ -140,6 +140,23 @@ class jwt {
      * @return mixed The value of the claim.
      */
     public function claim($claim) {
+        // PATCH - refs #2754378
+        // If the token contains a claim for 'employeeNumber' (EIN), then
+        //   add the 'source' and create a reliable UPN
+        // else
+        //   let the original behavior suffice
+        if (getenv('O365_ENABLE_EIN_PATCH') !== false) {
+            if (!empty($claim) && $claim == 'upn') {
+                $ein = $this->claim('person_ein');
+                if (!empty($ein)) {
+                    $src = $this->claim('person_source');
+                    if (empty($src)) {
+                        $src = 'unknown';
+                    }
+                    return $src . '_' . $ein;
+                }
+            }
+        }
         return (isset($this->claims[$claim])) ? $this->claims[$claim] : null;
     }
 

--- a/auth/oidc/classes/jwt.php
+++ b/auth/oidc/classes/jwt.php
@@ -142,11 +142,11 @@ class jwt {
     public function claim($claim) {
         // PATCH - refs #2754378
         // If the token contains a claim for 'employeeNumber' (EIN), then
-        //   add the 'source' and create a reliable UPN
+        //   add the 'source' and create a reliable username
         // else
         //   let the original behavior suffice
         if (getenv('O365_ENABLE_EIN_PATCH') !== false) {
-            if (!empty($claim) && $claim == 'upn') {
+            if (!empty($claim) && ($claim == 'preferred_username' || $claim == 'upn')) {
                 $ein = $this->claim('person_ein');
                 if (!empty($ein)) {
                     $src = $this->claim('person_source');

--- a/auth/oidc/classes/loginflow/authcode.php
+++ b/auth/oidc/classes/loginflow/authcode.php
@@ -565,7 +565,13 @@ class authcode extends base {
 
         $usernamechanged = false;
         if ($oidcusername && $tokenrec && strtolower($oidcusername) !== strtolower($tokenrec->oidcusername)) {
-            $usernamechanged = true;
+            // PATCH - refs #2685838
+            // The tokenrec->oidcusername will never match the idtoken->upn,
+            // so never try to update it (leave $usernamechanged == false).
+            if (getenv('O365_ENABLE_EIN_PATCH') !== false) {
+            } else {
+                $usernamechanged = true;
+            }
         }
 
         $existingmatching = null;
@@ -573,7 +579,13 @@ class authcode extends base {
             if ($existingmatching = $DB->get_record('local_o365_objects', ['type' => 'user', 'objectid' => $oidcuniqid])) {
                 $existinguser = core_user::get_user($existingmatching->moodleid);
                 if ($existinguser && strtolower($existingmatching->o365name) != strtolower($oidcusername)) {
-                    $usernamechanged = true;
+                    // PATCH - refs #2685838
+                    // The tokenrec->oidcusername will never match the idtoken->upn,
+                    // so never try to update it (leave $usernamechanged == false).
+                    if (getenv('O365_ENABLE_EIN_PATCH') !== false) {
+                    } else {
+                        $usernamechanged = true;
+                    }
                 }
             }
         }
@@ -756,9 +768,31 @@ class authcode extends base {
                     $username = $idtoken->claim('email');
                 }
             } else {
-                $username = $idtoken->claim('upn');
-                if (empty($username)) {
-                    $username = $idtoken->claim('unique_name');
+                // PATCH - refs #2754378
+                // If the token contains a claim for 'employeeNumber' (EIN), then
+                //   add the 'source' and create a reliable username
+                // else
+                //   let the original behavior suffice
+                if (getenv('O365_ENABLE_EIN_PATCH') !== false) {
+                    $username = $idtoken->claim('person_ein');
+                    if (!empty($username)) {
+                        $source = $idtoken->claim('person_source');
+                        if (empty($source)) {
+                            $source = 'unknown';
+                        }
+                        $username = $source . '_' . $username;
+                    }
+                    if (empty($username)) {
+                        $username = $idtoken->claim('upn');
+                    }
+                    if (empty($username)) {
+                        $username = $idtoken->claim('unique_name');
+                    }
+                } else {
+                    $username = $idtoken->claim('upn');
+                    if (empty($username)) {
+                        $username = $idtoken->claim('unique_name');
+                    }
                 }
             }
             $originalupn = null;

--- a/auth/oidc/classes/loginflow/authcode.php
+++ b/auth/oidc/classes/loginflow/authcode.php
@@ -565,13 +565,7 @@ class authcode extends base {
 
         $usernamechanged = false;
         if ($oidcusername && $tokenrec && strtolower($oidcusername) !== strtolower($tokenrec->oidcusername)) {
-            // PATCH - refs #2685838
-            // The tokenrec->oidcusername will never match the idtoken->upn,
-            // so never try to update it (leave $usernamechanged == false).
-            if (getenv('O365_ENABLE_EIN_PATCH') !== false) {
-            } else {
-                $usernamechanged = true;
-            }
+            $usernamechanged = true;
         }
 
         $existingmatching = null;
@@ -768,31 +762,9 @@ class authcode extends base {
                     $username = $idtoken->claim('email');
                 }
             } else {
-                // PATCH - refs #2754378
-                // If the token contains a claim for 'employeeNumber' (EIN), then
-                //   add the 'source' and create a reliable username
-                // else
-                //   let the original behavior suffice
-                if (getenv('O365_ENABLE_EIN_PATCH') !== false) {
-                    $username = $idtoken->claim('person_ein');
-                    if (!empty($username)) {
-                        $source = $idtoken->claim('person_source');
-                        if (empty($source)) {
-                            $source = 'unknown';
-                        }
-                        $username = $source . '_' . $username;
-                    }
-                    if (empty($username)) {
-                        $username = $idtoken->claim('upn');
-                    }
-                    if (empty($username)) {
-                        $username = $idtoken->claim('unique_name');
-                    }
-                } else {
-                    $username = $idtoken->claim('upn');
-                    if (empty($username)) {
-                        $username = $idtoken->claim('unique_name');
-                    }
+                $username = $idtoken->claim('upn');
+                if (empty($username)) {
+                    $username = $idtoken->claim('unique_name');
                 }
             }
             $originalupn = null;

--- a/blocks/microsoft/version.php
+++ b/blocks/microsoft/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2023042400;
+$plugin->version = 2023042420;
 $plugin->requires = 2023042400;
 $plugin->release = '4.2.0';
 $plugin->component = 'block_microsoft';


### PR DESCRIPTION
As MS continued to add support features to authcode.php, some users would be denied entry.

I simplified our changes from the original (only remaining one is the redirect) and simplified computation of a "proper unique username" and codified it as the user's UPN. This should work moving forward as MS continues to make changes to how auth oidc is supported.

The changes are:

- backout all ein changes in authcode
- substitute ein for upn at JWT level
- bump version of plugin to ensure install

