### PR TITLE
CUSTOM: log account creation details

### DIFF
--- a/auth/oidc/classes/event/user_account.php
+++ b/auth/oidc/classes/event/user_account.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * A user account was created via OIDC.
+ *
+ * @package auth_oidc
+ */
+
+namespace auth_oidc\event;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Event fired when a user account is created with OIDC.
+ */
+class user_account extends \core\event\base {
+    /**
+     * Return localised event name.
+     *
+     * @return string
+     */
+    public static function get_name() {
+        return get_string('eventaccountcreated', 'auth_oidc');
+    }
+
+    /**
+     * Returns non-localised event description with id's for admin use only.
+     *
+     * @return string
+     */
+    public function get_description() {
+        return json_encode($this->other);
+    }
+
+    /**
+     * Init method.
+     *
+     * @return void
+     */
+    protected function init() {
+        $this->context = \context_system::instance();
+        $this->data['crud'] = 'r';
+        $this->data['edulevel'] = self::LEVEL_OTHER;
+        $this->data['objecttable'] = 'user';
+    }
+}

--- a/auth/oidc/classes/event/user_rename_attempt.php
+++ b/auth/oidc/classes/event/user_rename_attempt.php
@@ -1,0 +1,66 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * A Moodle user rename attempt event.
+ *
+ * @package auth_oidc
+ * @author James McQuillan <james.mcquillan@remote-learner.net>
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright (C) 2014 onwards Microsoft, Inc. (http://microsoft.com/)
+ */
+
+namespace auth_oidc\event;
+
+use context_system;
+use core\event\base;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Fired when a user attempts to change their username from the auth_oidc plugin.
+ */
+class user_rename_attempt extends base {
+    /**
+     * Return localised event name.
+     *
+     * @return string
+     */
+    public static function get_name() {
+        return get_string('eventuserrenameattempt', 'auth_oidc');
+    }
+
+    /**
+     * Returns non-localised event description with id's for admin use only.
+     *
+     * @return string
+     */
+    public function get_description() {
+        return "The auth_oidc plugin attempts to change the username of the user with id '$this->userid'.";
+    }
+
+    /**
+     * Init method.
+     *
+     * @return void
+     */
+    protected function init() {
+        $this->context = context_system::instance();
+        $this->data['crud'] = 'u';
+        $this->data['edulevel'] = self::LEVEL_OTHER;
+        $this->data['objecttable'] = 'user';
+    }
+}

--- a/auth/oidc/classes/jwt.php
+++ b/auth/oidc/classes/jwt.php
@@ -140,6 +140,23 @@ class jwt {
      * @return mixed The value of the claim.
      */
     public function claim($claim) {
+        // PATCH - refs #2754378
+        // If the token contains a claim for 'employeeNumber' (EIN), then
+        //   add the 'source' and create a reliable UPN
+        // else
+        //   let the original behavior suffice
+        if (getenv('O365_ENABLE_EIN_PATCH') !== false) {
+            if (!empty($claim) && $claim == 'upn') {
+                $ein = $this->claim('person_ein');
+                if (!empty($ein)) {
+                    $src = $this->claim('person_source');
+                    if (empty($src)) {
+                        $src = 'unknown';
+                    }
+                    return $src . '_' . $ein;
+                }
+            }
+        }
         return (isset($this->claims[$claim])) ? $this->claims[$claim] : null;
     }
 

--- a/auth/oidc/classes/loginflow/authcode.php
+++ b/auth/oidc/classes/loginflow/authcode.php
@@ -573,7 +573,13 @@ class authcode extends base {
             if ($existingmatching = $DB->get_record('local_o365_objects', ['type' => 'user', 'objectid' => $oidcuniqid])) {
                 $existinguser = core_user::get_user($existingmatching->moodleid);
                 if ($existinguser && strtolower($existingmatching->o365name) != strtolower($oidcusername)) {
-                    $usernamechanged = true;
+                    // PATCH - refs #2685838
+                    // The tokenrec->oidcusername will never match the idtoken->upn,
+                    // so never try to update it (leave $usernamechanged == false).
+                    if (getenv('O365_ENABLE_EIN_PATCH') !== false) {
+                    } else {
+                        $usernamechanged = true;
+                    }
                 }
             }
         }

--- a/auth/oidc/classes/loginflow/authcode.php
+++ b/auth/oidc/classes/loginflow/authcode.php
@@ -565,7 +565,13 @@ class authcode extends base {
 
         $usernamechanged = false;
         if ($oidcusername && $tokenrec && strtolower($oidcusername) !== strtolower($tokenrec->oidcusername)) {
-            $usernamechanged = true;
+            // PATCH - refs #2685838
+            // The tokenrec->oidcusername will never match the idtoken->upn,
+            // so never try to update it (leave $usernamechanged == false).
+            if (getenv('O365_ENABLE_EIN_PATCH') !== false) {
+            } else {
+                $usernamechanged = true;
+            }
         }
 
         $existingmatching = null;
@@ -573,7 +579,13 @@ class authcode extends base {
             if ($existingmatching = $DB->get_record('local_o365_objects', ['type' => 'user', 'objectid' => $oidcuniqid])) {
                 $existinguser = core_user::get_user($existingmatching->moodleid);
                 if ($existinguser && strtolower($existingmatching->o365name) != strtolower($oidcusername)) {
-                    $usernamechanged = true;
+                    // PATCH - refs #2685838
+                    // The tokenrec->oidcusername will never match the idtoken->upn,
+                    // so never try to update it (leave $usernamechanged == false).
+                    if (getenv('O365_ENABLE_EIN_PATCH') !== false) {
+                    } else {
+                        $usernamechanged = true;
+                    }
                 }
             }
         }
@@ -756,9 +768,31 @@ class authcode extends base {
                     $username = $idtoken->claim('email');
                 }
             } else {
-                $username = $idtoken->claim('upn');
-                if (empty($username)) {
-                    $username = $idtoken->claim('unique_name');
+                // PATCH - refs #2754378
+                // If the token contains a claim for 'employeeNumber' (EIN), then
+                //   add the 'source' and create a reliable username
+                // else
+                //   let the original behavior suffice
+                if (getenv('O365_ENABLE_EIN_PATCH') !== false) {
+                    $username = $idtoken->claim('person_ein');
+                    if (!empty($username)) {
+                        $source = $idtoken->claim('person_source');
+                        if (empty($source)) {
+                            $source = 'unknown';
+                        }
+                        $username = $source . '_' . $username;
+                    }
+                    if (empty($username)) {
+                        $username = $idtoken->claim('upn');
+                    }
+                    if (empty($username)) {
+                        $username = $idtoken->claim('unique_name');
+                    }
+                } else {
+                    $username = $idtoken->claim('upn');
+                    if (empty($username)) {
+                        $username = $idtoken->claim('unique_name');
+                    }
                 }
             }
             $originalupn = null;

--- a/auth/oidc/classes/loginflow/authcode.php
+++ b/auth/oidc/classes/loginflow/authcode.php
@@ -381,7 +381,16 @@ class authcode extends base {
             if ($USER->id && $DB->record_exists('auth_oidc_token', ['userid' => $USER->id])) {
                 $DB->set_field('auth_oidc_token', 'sid', $sid, ['userid' => $USER->id]);
             }
-            redirect(core_login_get_return_url());
+
+            // PATCH - refs #1700609
+            // Redirects users to other site to cache the sites cookie in the browser session.
+            // URL encode the redirect URL because it may contain '&' or other restricted characters.
+            if (!empty(getenv('O365_CUSTOM_REDIRECT_URL'))) {
+                header("Location: ".getenv('O365_CUSTOM_REDIRECT_URL').urlencode(core_login_get_return_url()));
+                die();
+            } else {
+                redirect(core_login_get_return_url());
+            }
         }
     }
 

--- a/auth/oidc/classes/loginflow/base.php
+++ b/auth/oidc/classes/loginflow/base.php
@@ -228,7 +228,7 @@ class base {
                     if (empty($objectid)) {
                         $objectid = $token->claim('sub');
                     }
-                    if (!$objectid) {
+                    if (!empty($objectid)) {
                         $userdata['objectId'] = $objectid;
                     }
                 }

--- a/auth/oidc/classes/loginflow/base.php
+++ b/auth/oidc/classes/loginflow/base.php
@@ -149,7 +149,7 @@ class base {
 
                         if (!isset($userdata['objectId'])) {
                             $objectid = $token->claim('oid');
-                            if (!$objectid) {
+                            if (!empty($objectid)) {
                                 $userdata['objectId'] = $objectid;
                             }
                         }

--- a/auth/oidc/lang/en/auth_oidc.php
+++ b/auth/oidc/lang/en/auth_oidc.php
@@ -157,6 +157,7 @@ $string['application_updated_azure'] = 'OpenID Connect application setting was u
 <span class="warning" style="color: red;">Azure administrator will need to <b>Provide admin consent</b> and <b>Verify setup</b> again on the <a href="{$a}" target="_blank">Microsoft 365 integration configuration page</a> if "Identity Provider (IdP) Type" or "Client authentication method" settings are updated.</span>';
 
 $string['event_debug'] = 'Debug message';
+$string['eventaccountcreated'] = 'Creating account';
 
 $string['task_cleanup_oidc_state_and_token'] = 'Clean up OIDC state and invalid token';
 

--- a/auth/oidc/lang/en/auth_oidc.php
+++ b/auth/oidc/lang/en/auth_oidc.php
@@ -221,6 +221,7 @@ $string['eventusercreated'] = 'User created with OpenID Connect';
 $string['eventuserconnected'] = 'User connected to OpenID Connect';
 $string['eventuserloggedin'] = 'User Logged In with OpenID Connect';
 $string['eventuserdisconnected'] = 'User disconnected from OpenID Connect';
+$string['eventuserrenameattempt'] = 'The auth_oidc plugin attempted to rename a user';
 
 $string['oidc:manageconnection'] = 'Allow OpenID Connection and Disconnection';
 $string['oidc:manageconnectionconnect'] = 'Allow OpenID Connection';

--- a/auth/oidc/lang/en/auth_oidc.php
+++ b/auth/oidc/lang/en/auth_oidc.php
@@ -145,6 +145,8 @@ $string['cfg_field_mapping_desc'] = 'User profile data can be mapped from Open I
 <li>If Azure AD is used as the IdP, additional profile data can be made available by installing and configuring the <a href="https://moodle.org/plugins/local_o365">Microsoft 365 integration plugin (local_o365)</a>.</li>
 <li>If SDS profile sync feature is enabled in the local_o365 plugin, certain profile fields can be synchronised from SDS to Moodle. when running the "Sync with SDS" scheduled task, and will not happen when running the "Sync users with Azure AD" scheduled task, nor when user logs in.</li>
 </ul>';
+$string['cfg_cleanupoidctokens_key'] = 'Cleanup OpenID Connect Tokens';
+$string['cfg_cleanupoidctokens_desc'] = 'If your users are experiencing problems logging in using their Microsoft 365 account, trying cleaning up OpenID Connect tokens. This removes stray and incomplete tokens that can cause errors. WARNING: This may interrupt logins in-process, so it\'s best to do this during downtime.';
 $string['settings_section_basic'] = 'Basic settings';
 $string['settings_section_authentication'] = 'Authentication';
 $string['settings_section_endpoints'] = 'Endpoints';

--- a/auth/oidc/version.php
+++ b/auth/oidc/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2023042410;
+$plugin->version = 2023042411;
 $plugin->requires = 2023042400;
 $plugin->release = '4.2.2';
 $plugin->component = 'auth_oidc';

--- a/auth/oidc/version.php
+++ b/auth/oidc/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2023042406;
+$plugin->version = 2023042410;
 $plugin->requires = 2023042400;
-$plugin->release = '4.2.1';
+$plugin->release = '4.2.2';
 $plugin->component = 'auth_oidc';
 $plugin->maturity = MATURITY_STABLE;

--- a/auth/oidc/version.php
+++ b/auth/oidc/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2023042405;
+$plugin->version = 2023042406;
 $plugin->requires = 2023042400;
 $plugin->release = '4.2.1';
 $plugin->component = 'auth_oidc';

--- a/local/o365/classes/feature/calsync/observers.php
+++ b/local/o365/classes/feature/calsync/observers.php
@@ -193,7 +193,7 @@ class observers {
     }
 
     /**
-     * Handle user_deleted event - clean up calendar subscriptions.
+     * Handle user_deleted event - clean up calendar subscriptions, mapping, and settings.
      *
      * @param \core\event\user_deleted $event The triggered event.
      * @return bool Success/Failure.
@@ -202,6 +202,9 @@ class observers {
         global $DB;
         $userid = $event->objectid;
         $DB->delete_records('local_o365_calsub', ['user_id' => $userid]);
+        $DB->delete_records('local_o365_calidmap', ['userid' => $userid]);
+        $DB->delete_records('local_o365_calsettings', ['user_id' => $userid]);
+
         return true;
     }
 }

--- a/local/o365/classes/feature/sds/task/sync.php
+++ b/local/o365/classes/feature/sds/task/sync.php
@@ -616,7 +616,11 @@ class sync extends scheduled_task {
 
         // Clean up schools.
         $enabledschools = get_config('local_o365', 'sdsschools');
-        $enabledschools = explode(',', $enabledschools);
+        if ($enabledschools) {
+            $enabledschools = explode(',', $enabledschools);
+        } else {
+            $enabledschools = [];
+        }
         foreach ($syncedsdsschools as $syncedsdsschool) {
             if (!in_array($syncedsdsschool->objectid, $enabledschools)) {
                 static::mtrace('Deleting SDS sync record for school ' . $syncedsdsschool->o365name . ' (' .

--- a/local/o365/classes/feature/usersync/main.php
+++ b/local/o365/classes/feature/usersync/main.php
@@ -1137,7 +1137,7 @@ class main {
             if (!isset($existingusers[$aaduser['upnlower']]) && !isset($existingusers[$aaduser['upnsplit0']]) &&
                 !isset($existingusers[$aaduser['convertedupn']])) {
                 // Check if the user has been renamed.
-                $syncnewuser = true;
+                $syncnewuser = array_key_exists('create', $aadsync);
                 if (isset($aaduser['id']) && $aaduser['id'] && $existingusermatching = $DB->get_record('local_o365_objects',
                         ['type' => 'user', 'objectid' => $aaduser['id']])) {
                     // This is a previously connected user who has been renamed in Microsoft.

--- a/local/o365/classes/oauth2/systemtoken.php
+++ b/local/o365/classes/oauth2/systemtoken.php
@@ -39,10 +39,12 @@ class systemtoken extends \local_o365\oauth2\token {
      * @param string $tokenresource The new resource.
      * @param \local_o365\oauth2\clientdata $clientdata Client information.
      * @param \local_o365\httpclientinterface $httpclient An HTTP client.
+     * @param bool $forcecreate
      *
      * @return \local_o365\oauth2\token|bool A constructed token for the new resource, or false if failure.
      */
-    public static function instance($userid, $tokenresource, \local_o365\oauth2\clientdata $clientdata, $httpclient) {
+    public static function instance($userid, $tokenresource, \local_o365\oauth2\clientdata $clientdata, $httpclient,
+                                    $forcecreate = false) {
     }
 
     /**

--- a/local/o365/classes/webservices/create_onenoteassignment.php
+++ b/local/o365/classes/webservices/create_onenoteassignment.php
@@ -27,14 +27,17 @@ namespace local_o365\webservices;
 
 defined('MOODLE_INTERNAL') || die();
 
+use core_external\external_api;
+
 global $CFG;
 
 require_once($CFG->dirroot.'/course/modlib.php');
+require_once($CFG->libdir.'/externallib.php');
 
 /**
  * Create assignment API class.
  */
-class create_onenoteassignment extends \external_api {
+class create_onenoteassignment extends external_api {
     /**
      * Returns description of method parameters.
      *

--- a/local/o365/classes/webservices/delete_onenoteassignment.php
+++ b/local/o365/classes/webservices/delete_onenoteassignment.php
@@ -27,14 +27,17 @@ namespace local_o365\webservices;
 
 defined('MOODLE_INTERNAL') || die();
 
+use core_external\external_api;
+
 global $CFG;
 
 require_once($CFG->dirroot.'/course/modlib.php');
+require_once($CFG->libdir.'/externallib.php');
 
 /**
  * Delete assignment API class.
  */
-class delete_onenoteassignment extends \external_api {
+class delete_onenoteassignment extends external_api {
     /**
      * Returns description of method parameters.
      *

--- a/local/o365/classes/webservices/read_assignments.php
+++ b/local/o365/classes/webservices/read_assignments.php
@@ -27,6 +27,8 @@ namespace local_o365\webservices;
 
 defined('MOODLE_INTERNAL') || die();
 
+use core_external\external_api;
+
 global $CFG;
 
 require_once($CFG->dirroot.'/course/modlib.php');
@@ -37,7 +39,7 @@ require_once($CFG->dirroot.'/mod/assign/locallib.php');
 /**
  * Get a list of assignments in one or more courses.
  */
-class read_assignments extends \external_api {
+class read_assignments extends external_api {
 
     /**
      * Returns description of method parameters

--- a/local/o365/classes/webservices/read_bot_message.php
+++ b/local/o365/classes/webservices/read_bot_message.php
@@ -27,10 +27,14 @@ namespace local_o365\webservices;
 
 defined('MOODLE_INTERNAL') || die();
 
+use core_external\external_api;
+
+require_once($CFG->libdir.'/externallib.php');
+
 /**
  * Get help card for user.
  */
-class read_bot_message extends \external_api {
+class read_bot_message extends external_api {
 
     /**
      * Returns description of method parameters

--- a/local/o365/classes/webservices/read_courseusers.php
+++ b/local/o365/classes/webservices/read_courseusers.php
@@ -27,14 +27,17 @@ namespace local_o365\webservices;
 
 defined('MOODLE_INTERNAL') || die();
 
+use core_external\external_api;
+
 global $CFG;
 
 require_once($CFG->dirroot.'/course/modlib.php');
+require_once($CFG->libdir.'/externallib.php');
 
 /**
  * Get a list of students in a course by course id.
  */
-class read_courseusers extends \external_api {
+class read_courseusers extends external_api {
     /**
      * Return description of method parameters.
      *

--- a/local/o365/classes/webservices/read_onenoteassignment.php
+++ b/local/o365/classes/webservices/read_onenoteassignment.php
@@ -27,14 +27,17 @@ namespace local_o365\webservices;
 
 defined('MOODLE_INTERNAL') || die();
 
+use core_external\external_api;
+
 global $CFG;
 
 require_once($CFG->dirroot.'/course/modlib.php');
+require_once($CFG->libdir.'/externallib.php');
 
 /**
  * Read assignment API class.
  */
-class read_onenoteassignment extends \external_api {
+class read_onenoteassignment extends external_api {
     /**
      * Returns description of method parameters.
      *

--- a/local/o365/classes/webservices/read_teachercourses.php
+++ b/local/o365/classes/webservices/read_teachercourses.php
@@ -27,14 +27,17 @@ namespace local_o365\webservices;
 
 defined('MOODLE_INTERNAL') || die();
 
+use core_external\external_api;
+
 global $CFG;
 
 require_once($CFG->dirroot.'/course/modlib.php');
+require_once($CFG->libdir.'/externallib.php');
 
 /**
  * Get a list of courses where the current user is a teacher.
  */
-class read_teachercourses extends \external_api {
+class read_teachercourses extends external_api {
     /**
      * Returns description of method parameters
      *

--- a/local/o365/classes/webservices/update_grade.php
+++ b/local/o365/classes/webservices/update_grade.php
@@ -25,9 +25,10 @@
 
 namespace local_o365\webservices;
 
-use \local_o365\webservices\exception as exception;
-
 defined('MOODLE_INTERNAL') || die();
+
+use local_o365\webservices\exception as exception;
+use core_external\external_api;
 
 global $CFG;
 
@@ -39,7 +40,7 @@ require_once($CFG->dirroot.'/mod/assign/locallib.php');
 /**
  * Update a grade.
  */
-class update_grade extends \external_api {
+class update_grade extends external_api {
     /**
      * Returns description of method parameters.
      *

--- a/local/o365/classes/webservices/update_onenoteassignment.php
+++ b/local/o365/classes/webservices/update_onenoteassignment.php
@@ -25,18 +25,20 @@
 
 namespace local_o365\webservices;
 
-use \local_o365\webservices\exception as exception;
-
 defined('MOODLE_INTERNAL') || die();
+
+use local_o365\webservices\exception as exception;
+use core_external\external_api;
 
 global $CFG;
 
 require_once($CFG->dirroot.'/course/modlib.php');
+require_once($CFG->libdir.'/externallib.php');
 
 /**
  * Update assignment API class.
  */
-class update_onenoteassignment extends \external_api {
+class update_onenoteassignment extends external_api {
     /**
      * Returns description of method parameters.
      *

--- a/local/o365/db/upgrade.php
+++ b/local/o365/db/upgrade.php
@@ -929,5 +929,29 @@ function xmldb_local_o365_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2023042402, 'local', 'o365');
     }
 
+    if ($oldversion < 2023042407) {
+        $deleteduserids = $DB->get_fieldset_select('user', 'id', 'deleted = 1');
+
+        if ($deleteduserids) {
+            // Delete records in local_o365_calidmap.
+            [$useridsql, $params] = $DB->get_in_or_equal($deleteduserids);
+            $sql = "DELETE FROM {local_o365_calidmap}
+                          WHERE userid {$useridsql}";
+            $DB->execute($sql, $params);
+
+            // Delete records in local_o365_calsettings.
+            $sql = "DELETE FROM {local_o365_calsettings}
+                          WHERE user_id {$useridsql}";
+            $DB->execute($sql, $params);
+
+            // Delete records in local_o365_calsub.
+            $sql = "DELETE FROM {local_o365_calsub}
+                          WHERE user_id {$useridsql}";
+            $DB->execute($sql, $params);
+        }
+
+        upgrade_plugin_savepoint(true, 2023042407, 'local', 'o365');
+    }
+
     return true;
 }

--- a/local/o365/db/upgrade.php
+++ b/local/o365/db/upgrade.php
@@ -723,6 +723,10 @@ function xmldb_local_o365_upgrade($oldversion) {
         if ($systemtokensconfig !== false) {
             $systemtokensconfig = unserialize($systemtokensconfig);
             foreach ($systemtokensconfig as $resource => $tokenconfig) {
+                // Make sure this is an array.
+                if (!is_array($tokenconfig)) {
+                    continue;
+                }
                 if (array_key_exists('resource', $tokenconfig)) {
                     $systemtokensconfig[$resource]['tokenresource'] = $tokenconfig['resource'];
                     unset($systemtokensconfig[$resource]['resource']);

--- a/local/o365/lang/en/local_o365.php
+++ b/local/o365/lang/en/local_o365.php
@@ -158,6 +158,118 @@ $string['settings_addsync_tzsynconlogin'] = 'Sync Outlook timezone to Moodle on 
 $string['settings_aadsync_guestsync'] = 'Sync guest users';
 $string['settings_suspend_delete_running_time'] = 'User suspension/deletion running time';
 $string['settings_suspend_delete_running_time_desc'] = 'If the option is enabled, suspension/delete feature of user sync function will run once a day, at the time configured in the Moodle instance default time zone.';
+$string['settings_support_upn_change'] = 'Support Microsoft account UPN change';
+$string['settings_support_upn_change_desc'] = 'If enabled, Moodle will try to react when the UPN of a Microsoft account that is connected to a Moodle account is changed.</br>
+<table class="flexible table table-striped table-hover generaltable generalbox table-sm">
+    <tr>
+        <th>Case ID</th>
+        <th>The user with the old username has logged in already? (token created)<br/>
+        <span class="support_upn_change_case_detail">Whether a token is saved in the auth_oidc_token table</span>
+        </th>
+        <th>First action after UPN rename<br/>
+        <span class="support_upn_change_case_detail">Either Login or User sync task run</span>
+        </th>
+        <th>Has potential duplicate username<br/>
+        <span class="support_upn_change_case_detail">Whether renaming would cause a username conflicts in Moodle</span>
+        </th>
+        <th>Expected behaviours</th>
+    </tr>
+    <tr>
+        <td>1</td>
+        <td>Yes</td>
+        <td>Login</td>
+        <td>No</td>
+        <td>
+            <ol>
+                <li>Rename the Moodle user.</li>
+                <li>auth_oidc_token updated with both new values for both "username" and "oidcusername" fields.</li>
+                <li>local_o365_objects user connection record "o365name" field updated to new value.</li>        
+            </ol>
+        </td>
+    </tr>
+    <tr>
+        <td>2</td>
+        <td>Yes</td>
+        <td>User sync</td>
+        <td>No</td>
+        <td>
+            <ol>
+                <li>Rename the Moodle user.</li>
+                <li>local_o365_objects user connection record is updated.</li>
+                <li>auth_oidc_token updated.</li>        
+            </ol>
+        </td>
+    </tr>
+    <tr>
+        <td>3</td>
+        <td>No</td>
+        <td>Login</td>
+        <td>No</td>
+        <td>
+            <ol>
+                <li>Rename the Moodle user.</li>
+                <li>local_o365_objects user connection record is updated.</li>
+                <li>auth_oidc_token updated.</li>        
+            </ol>
+        </td>
+    </tr>
+    <tr>
+        <td>4</td>
+        <td>No</td>
+        <td>User sync</td>
+        <td>No</td>
+        <td>
+            <ol>
+                <li>Rename the Moodle user.</li>
+                <li>local_o365_objects user connection record is updated.</li>      
+            </ol>
+        </td>
+    </tr>
+    <tr>
+        <td>5</td>
+        <td>Yes</td>
+        <td>Login</td>
+        <td>Yes</td>
+        <td>
+            <ol>
+                <li>Throw exception and do not rename Moodle user.</li>
+            </ol>
+        </td>
+    </tr>
+    <tr>
+        <td>6</td>
+        <td>Yes</td>
+        <td>User sync</td>
+        <td>Yes</td>
+        <td>
+            <ol>
+                <li>Display error message saying rename attempt failed in user sync task run.</li>
+            </ol>
+        </td>
+    </tr>
+    <tr>
+        <td>7</td>
+        <td>No</td>
+        <td>Login</td>
+        <td>Yes</td>
+        <td>
+            <ol>
+                <li>Throw exception and do not rename Moodle user.</li>
+            </ol>
+        </td>
+    </tr>
+    <tr>
+        <td>8</td>
+        <td>No</td>
+        <td>Unser sync</td>
+        <td>Yes</td>
+        <td>
+            <ol>
+                <li>Display error message saying rename attempt failed in user sync task run.</li>
+            </ol>
+        </td>
+    </tr>
+</table>';
 
 // User field mapping.
 $string['settings_fieldmap'] = 'User field mapping';
@@ -630,6 +742,7 @@ $string['erroro365apinotoken'] = 'Did not have a token for the given resource an
 $string['erroro365apisiteexistsnolocal'] = 'Site already exists, but could not find local record.';
 $string['errorusermatched'] = 'The Microsoft 365 account "{$a->aadupn}" is already matched with Moodle user "{$a->username}". To complete the connection, please log in as that Moodle user first and follow the instructions in the Microsoft block.';
 $string['eventapifail'] = 'API failure';
+$string['errorupnchangeisnotsupported'] = 'Your Microsoft account UPN has changed. Please contact your administrator to update your Moodle account.';
 
 // Privacy API.
 $string['privacy:metadata:local_o365'] = 'Microsoft 365 Local Plugin';

--- a/local/o365/settings.php
+++ b/local/o365/settings.php
@@ -179,27 +179,36 @@ if ($hassiteconfig) {
         $desc = new lang_string('settings_options_usersync_desc', 'local_o365');
         $settings->add(new admin_setting_heading('local_o365_options_usersync', $label, $desc));
 
+        // User sync options.
         $label = new lang_string('settings_aadsync', 'local_o365');
         $scheduledtasks = new moodle_url('/admin/tool/task/scheduledtasks.php');
         $desc = new lang_string('settings_aadsync_details', 'local_o365', $scheduledtasks->out());
         $aadsyncsettings = new aadsyncoptions('local_o365/aadsync', $label, $desc);
         $settings->add($aadsyncsettings);
 
+        // User creation restrictions.
         $key = 'local_o365/usersynccreationrestriction';
         $label = new lang_string('settings_usersynccreationrestriction', 'local_o365');
         $desc = new lang_string('settings_usersynccreationrestriction_details', 'local_o365');
         $default = [];
         $settings->add(new usersynccreationrestriction($key, $label, $desc, $default));
 
+        // Link to filter mapping settings.
         $label = new lang_string('settings_fieldmap', 'local_o365');
         $oidcsettingspageurl = new moodle_url('/admin/settings.php', ['section' => 'auth_oidc_field_mapping']);
         $desc = new lang_string('settings_fieldmap_details', 'local_o365', $oidcsettingspageurl->out(false));
         $settings->add(new auth_oidc_admin_setting_label('local_o365/fieldmap', $label, $desc, null));
 
+        // User suspension / deletion running time.
         $label = new lang_string('settings_suspend_delete_running_time', 'local_o365');
         $desc = new lang_string('settings_suspend_delete_running_time_desc', 'local_o365');
         $settings->add(new admin_setting_configtime('local_o365/usersync_suspension_h', 'usersync_suspension_m',
             $label, $desc, ['h' => 2, 'm' => 30]));
+
+        // Toggle to control whether to support upn change.
+        $label = new lang_string('settings_support_upn_change', 'local_o365');
+        $desc = new lang_string('settings_support_upn_change_desc', 'local_o365');
+        $settings->add(new admin_setting_configcheckbox('local_o365/support_upn_change', $label, $desc, '0'));
 
         // Course sync section.
         $label = new lang_string('settings_secthead_coursesync', 'local_o365');

--- a/local/o365/settings.php
+++ b/local/o365/settings.php
@@ -110,6 +110,12 @@ if ($hassiteconfig) {
             $desc = new lang_string('settings_setup_step2_desc', 'local_o365');
 
             $systemapiuser = get_config('local_o365', 'systemtokens');
+            $enableapponlyaccess = get_config('local_o365', 'enableapponlyaccess');
+            if (!empty($enableapponlyaccess) && !empty($systemapiuser)) {
+                // Both "Application access" and "System API user" are enabled - we simply disable "System API user".
+                unset_config('systemtokens', 'local_o365');
+                $systemapiuser = null;
+            }
             if (!empty($systemapiuser)) {
                 // Show option to convert to app only access.
                 $desc .= new lang_string('settings_setup_step2_desc_additional', 'local_o365');

--- a/local/o365/styles.css
+++ b/local/o365/styles.css
@@ -292,6 +292,11 @@ button.local_o365_manual_login_button:focus, button.local_o365_manual_login_butt
     padding-top: 10px;
 }
 
+.support_upn_change_case_detail {
+    font-weight: normal;
+    font-size: 0.8rem;
+}
+
 #admin-bot_app_id,
 #admin-bot_app_password,
 #admin-bot_feature_enabled,

--- a/local/o365/version.php
+++ b/local/o365/version.php
@@ -26,7 +26,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2023042405;
+$plugin->version = 2023042407;
 $plugin->requires = 2023042400;
 $plugin->release = '4.2.1';
 $plugin->component = 'local_o365';

--- a/local/o365/version.php
+++ b/local/o365/version.php
@@ -26,11 +26,11 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2023042407;
+$plugin->version = 2023042410;
 $plugin->requires = 2023042400;
-$plugin->release = '4.2.1';
+$plugin->release = '4.2.2';
 $plugin->component = 'local_o365';
 $plugin->maturity = MATURITY_STABLE;
 $plugin->dependencies = [
-    'auth_oidc' => 2023042405,
+    'auth_oidc' => 2023042410,
 ];

--- a/local/office365/version.php
+++ b/local/office365/version.php
@@ -25,15 +25,15 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2023042405;
+$plugin->version = 2023042410;
 $plugin->requires = 2023042400;
-$plugin->release = '4.2.1';
+$plugin->release = '4.2.2';
 $plugin->component = 'local_office365';
 $plugin->maturity = MATURITY_STABLE;
 $plugin->dependencies = [
-    'auth_oidc' => 2023042405,
+    'auth_oidc' => 2023042410,
     'block_microsoft' => 2023042400,
-    'local_o365' => 2023042405,
+    'local_o365' => 2023042410,
     'repository_office365' => 2023042400,
     'theme_boost_o365teams' => 2023042405,
 ];


### PR DESCRIPTION
When users are created in Moodle, they use details from the provided token to create the username.

Of the multiple thousands of new users each week less than 1% fail to register properly. 1% of a large number is still too many.

The PR contains the following:
- All other local, custom changes
- a new event to send data to the Moodle log
- an additional string for the new event
- a new feature flag "O365_LOG_ACCT_CREATE_DATA"
- code to trigger the new event before each account creation