### PR TITLE
log account creation details

### DIFF
--- a/auth/oidc/classes/event/user_account.php
+++ b/auth/oidc/classes/event/user_account.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * A user account was created via OIDC.
+ *
+ * @package auth_oidc
+ */
+
+namespace auth_oidc\event;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Event fired when a user account is created with OIDC.
+ */
+class user_account extends \core\event\base {
+    /**
+     * Return localised event name.
+     *
+     * @return string
+     */
+    public static function get_name() {
+        return get_string('eventaccountcreated', 'auth_oidc');
+    }
+
+    /**
+     * Returns non-localised event description with id's for admin use only.
+     *
+     * @return string
+     */
+    public function get_description() {
+        return json_encode($this->other);
+    }
+
+    /**
+     * Init method.
+     *
+     * @return void
+     */
+    protected function init() {
+        $this->context = \context_system::instance();
+        $this->data['crud'] = 'r';
+        $this->data['edulevel'] = self::LEVEL_OTHER;
+        $this->data['objecttable'] = 'user';
+    }
+}

--- a/auth/oidc/classes/loginflow/authcode.php
+++ b/auth/oidc/classes/loginflow/authcode.php
@@ -565,7 +565,13 @@ class authcode extends base {
 
         $usernamechanged = false;
         if ($oidcusername && $tokenrec && strtolower($oidcusername) !== strtolower($tokenrec->oidcusername)) {
-            $usernamechanged = true;
+            // PATCH - refs #2685838
+            // The tokenrec->oidcusername will never match the idtoken->upn,
+            // so never try to update it (leave $usernamechanged == false).
+            if (getenv('O365_ENABLE_EIN_PATCH') !== false) {
+            } else {
+                $usernamechanged = true;
+            }
         }
 
         $existingmatching = null;
@@ -573,7 +579,13 @@ class authcode extends base {
             if ($existingmatching = $DB->get_record('local_o365_objects', ['type' => 'user', 'objectid' => $oidcuniqid])) {
                 $existinguser = core_user::get_user($existingmatching->moodleid);
                 if ($existinguser && strtolower($existingmatching->o365name) != strtolower($oidcusername)) {
-                    $usernamechanged = true;
+                    // PATCH - refs #2685838
+                    // The tokenrec->oidcusername will never match the idtoken->upn,
+                    // so never try to update it (leave $usernamechanged == false).
+                    if (getenv('O365_ENABLE_EIN_PATCH') !== false) {
+                    } else {
+                        $usernamechanged = true;
+                    }
                 }
             }
         }
@@ -756,9 +768,31 @@ class authcode extends base {
                     $username = $idtoken->claim('email');
                 }
             } else {
-                $username = $idtoken->claim('upn');
-                if (empty($username)) {
-                    $username = $idtoken->claim('unique_name');
+                // PATCH - refs #2754378
+                // If the token contains a claim for 'employeeNumber' (EIN), then
+                //   add the 'source' and create a reliable username
+                // else
+                //   let the original behavior suffice
+                if (getenv('O365_ENABLE_EIN_PATCH') !== false) {
+                    $username = $idtoken->claim('person_ein');
+                    if (!empty($username)) {
+                        $source = $idtoken->claim('person_source');
+                        if (empty($source)) {
+                            $source = 'unknown';
+                        }
+                        $username = $source . '_' . $username;
+                    }
+                    if (empty($username)) {
+                        $username = $idtoken->claim('upn');
+                    }
+                    if (empty($username)) {
+                        $username = $idtoken->claim('unique_name');
+                    }
+                } else {
+                    $username = $idtoken->claim('upn');
+                    if (empty($username)) {
+                        $username = $idtoken->claim('unique_name');
+                    }
                 }
             }
             $originalupn = null;

--- a/auth/oidc/lang/en/auth_oidc.php
+++ b/auth/oidc/lang/en/auth_oidc.php
@@ -157,6 +157,7 @@ $string['application_updated_azure'] = 'OpenID Connect application setting was u
 <span class="warning" style="color: red;">Azure administrator will need to <b>Provide admin consent</b> and <b>Verify setup</b> again on the <a href="{$a}" target="_blank">Microsoft 365 integration configuration page</a> if "Identity Provider (IdP) Type" or "Client authentication method" settings are updated.</span>';
 
 $string['event_debug'] = 'Debug message';
+$string['eventaccountcreated'] = 'Creating account';
 
 $string['task_cleanup_oidc_state_and_token'] = 'Clean up OIDC state and invalid token';
 

--- a/auth/oidc/version.php
+++ b/auth/oidc/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2023042410;
+$plugin->version = 2023042411;
 $plugin->requires = 2023042400;
 $plugin->release = '4.2.2';
 $plugin->component = 'auth_oidc';


### PR DESCRIPTION
When users are created in Moodle, they use details from the provided token to create the username.

Of the multiple thousands of new users each week less than 1% fail to register properly. 1% of a large number is still too many.

This PR contains the following:

- a new event to send data to the Moodle log
- an additional string for the new event
- a new feature flag "O365_LOG_ACCT_CREATE_DATA"
- code to trigger the new event before each account creation